### PR TITLE
No dist-xz for EL5 (and perhaps for some other stable systems)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_INIT([libilbc], [1.1.1], [])
 AC_CONFIG_AUX_DIR(.)
 AC_CONFIG_MACRO_DIR([m4])
-AM_INIT_AUTOMAKE([tar-ustar dist-xz foreign])
+AM_INIT_AUTOMAKE([tar-ustar dist-bzip2 foreign])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 # Setup for libtool


### PR DESCRIPTION
Some prominent Enterprise Linux distributions doesn't have a recent autotools versions with xz support. So it should be better to stick with dist-bzip2 for now (until 2017, when one well-known North-American Linux vendor plans to discontinue support for his Enterprise Linux 5 distro).

Signed-off-by: Peter Lemenkov lemenkov@gmail.com
