### PR TITLE
Compile also test application for simple iLBC encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,9 @@ set_target_properties(ilbc PROPERTIES VERSION ${PACKAGE_VERSION} SOVERSION 2)
 set_target_properties(ilbc PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 target_link_libraries(ilbc ${CMAKE_THREAD_LIBS_INIT})
 
+add_executable(ilbc_test ilbc/test/iLBC_test.c)
+target_link_libraries(ilbc_test ilbc)
+
 #############################################################################
 ## Compiler flags
 #############################################################################
@@ -197,7 +200,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libilbc.pc
         DESTINATION ${libdir}/pkgconfig)
 install(FILES ilbc/interface/ilbc.h
         DESTINATION ${includedir})
-install(TARGETS ilbc
+install(TARGETS ilbc ilbc_test
         ARCHIVE DESTINATION ${libdir}
         LIBRARY DESTINATION ${libdir}
         RUNTIME DESTINATION bin)

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,8 @@ libilbcinclude_HEADERS = $(top_srcdir)/ilbc/interface/ilbc.h
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libilbc.pc
 
+bin_PROGRAMS = ilbc_test
+
 lib_LTLIBRARIES = libilbc.la
 
 libilbc_la_LDFLAGS = -version-info @LIBILBC_VERSION@ -no-undefined
@@ -205,6 +207,12 @@ libilbc_la_SOURCES = \
     $(ilbc_headers) \
     $(sigproc_sources) \
     $(sigproc_headers)
+
+ilbc_test_SOURCES = \
+    ilbc/test/iLBC_test.c
+
+ilbc_test_LDADD = \
+    libilbc.la
 
 dist_doc_DATA = \
     $(top_srcdir)/NEWS.md \


### PR DESCRIPTION
This application can be used for encoding RAW s16le PCM samples to iLBC.