### PR TITLE
add riscv64 support

### DIFF
--- a/typedefs.h
+++ b/typedefs.h
@@ -26,6 +26,9 @@
 #elif defined(__aarch64__)
 #define WEBRTC_ARCH_64_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__riscv64__) || (defined(__riscv) && __riscv_xlen == 64)
+#define WEBRTC_ARCH_64_BITS
+#define WEBRTC_ARCH_LITTLE_ENDIAN
 #elif defined(_M_IX86) || defined(__i386__)
 #define WEBRTC_ARCH_X86_FAMILY
 #define WEBRTC_ARCH_X86


### PR DESCRIPTION
riscv64 support
In OpenMandriva linux we already ported this package to riscv64
https://abf.openmandriva.org/build_lists/26990
well why not to send this small patch to upstream.