### PR TITLE
Fix install when using a separated build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,7 +323,7 @@ add_custom_target(ilbc_test-sample
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libilbc.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-install(FILES ilbc.h ilbc_export.h
+install(FILES ilbc.h ${CMAKE_CURRENT_BINARY_DIR}/ilbc_export.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES CONTRIBUTING.md NEWS.md README.md
         DESTINATION ${CMAKE_INSTALL_DOCDIR})


### PR DESCRIPTION
This fixes the following error at `make install` time when using a separated build directory (out-of-tree build):

```
CMake Error at cmake_install.cmake:50 (file):
  file INSTALL cannot find "/build/libilbc/src/libilbc/ilbc_export.h": No
  such file or directory.


make: *** [Makefile:105: install] Error 1
make: Leaving directory '/build/libilbc/src/build'
```

How to reproduce:

```
$ git clone --recursive https://github.com/TimothyGu/libilbc.git
$ cmake -B build -S libilbc
$ make -C build
$ make -C build install
```

Fixes #28