### PR TITLE
add platform definition for IA64

### DIFF
--- a/rtc_base/system/arch.h
+++ b/rtc_base/system/arch.h
@@ -79,6 +79,9 @@
 #elif defined(__EMSCRIPTEN__)
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(_M_IA64) || defined(__ia64__) || defined(__ia64)
+#define WEBRTC_ARCH_64_BITS
+#define WEBRTC_ARCH_LITTLE_ENDIAN
 #else
 #error Please add support for your architecture in rtc_base/system/arch.h
 #endif


### PR DESCRIPTION
How I tested:
    * built ffmpeg with libilbc enabled
    * obtained a sample file from
      https://web.archive.org/web/2016*/http://www.andrews-corner.org/samples/luckynight.lbc
    * converted it to wav using ffmpeg on ia64 host
    * compared to file converted on amd64 host
    * did the same in reverse (converted wav to lbc)

All comparisons were identical and sounded the same.