### PR TITLE
Switch order of function decorators

### DIFF
--- a/modules/audio_coding/codecs/ilbc/decode.h
+++ b/modules/audio_coding/codecs/ilbc/decode.h
@@ -31,8 +31,8 @@
  *---------------------------------------------------------------*/
 
 // Returns 0 on success, -1 on error.
-ILBC_EXPORT
 ABSL_MUST_USE_RESULT
+ILBC_EXPORT
 int WebRtcIlbcfix_DecodeImpl(
     int16_t* decblock,         /* (o) decoded signal block */
     const uint16_t* bytes,     /* (i) encoded signal bits */


### PR DESCRIPTION
The USE_RESULT macro can be an attribute, given recent enough gcc. Those have to come first, otherwise the signature is invalid.