### PR TITLE
Add preprocessor support for loongarch architectures

### DIFF
--- a/rtc_base/system/arch.h
+++ b/rtc_base/system/arch.h
@@ -73,6 +73,14 @@
 #elif defined(__riscv) && __riscv_xlen == 32
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__loongarch__) && __loongarch_grlen == 64
+#define WEBRTC_ARCH_LOONGARCH_FAMILY
+#define WEBRTC_ARCH_64_BITS
+#define WEBRTC_ARCH_LITTLE_ENDIAN
+#elif defined(__loongarch__) && __loongarch_grlen == 32
+#define WEBRTC_ARCH_LOONGARCH_FAMILY
+#define WEBRTC_ARCH_32_BITS
+#define WEBRTC_ARCH_LITTLE_ENDIAN
 #elif defined(__pnacl__)
 #define WEBRTC_ARCH_32_BITS
 #define WEBRTC_ARCH_LITTLE_ENDIAN


### PR DESCRIPTION
__loongarch__ and __loongarch_grlen are defined by https://github.com/loongson/la-toolchain-conventions#cc-preprocessor-built-in-macro-definitions